### PR TITLE
Update examples for motor API changes

### DIFF
--- a/official_models/ev3/education_core/puppy/main.py
+++ b/official_models/ev3/education_core/puppy/main.py
@@ -278,8 +278,8 @@ class Puppy:
         while not self.left_leg_motor.control.done():
             wait(100)
 
-        self.left_leg_motor.run_target(50, self.STAND_UP_ANGLE, Stop.HOLD, wait=False)
-        self.right_leg_motor.run_target(50, self.STAND_UP_ANGLE, Stop.HOLD)
+        self.left_leg_motor.run_target(50, self.STAND_UP_ANGLE, wait=False)
+        self.right_leg_motor.run_target(50, self.STAND_UP_ANGLE)
         while not self.left_leg_motor.control.done():
             wait(100)
 
@@ -306,14 +306,14 @@ class Puppy:
         self.left_leg_motor.run(500)
         self.right_leg_motor.run(500)
         wait(275)
-        self.left_leg_motor.stop(Stop.HOLD)
-        self.right_leg_motor.stop(Stop.HOLD)
+        self.left_leg_motor.hold()
+        self.right_leg_motor.hold()
         wait(275)
         self.left_leg_motor.run(-50)
         self.right_leg_motor.run(-50)
         wait(275)
-        self.left_leg_motor.stop(Stop.COAST)
-        self.right_leg_motor.stop(Stop.COAST)
+        self.left_leg_motor.stop()
+        self.right_leg_motor.stop()
 
     @property
     def behavior(self):

--- a/official_models/ev3/education_core/robot_arm/main.py
+++ b/official_models/ev3/education_core/robot_arm/main.py
@@ -47,7 +47,7 @@ elbow_motor.run(15)
 while elbow_sensor.reflection() < 32:
     wait(10)
 elbow_motor.reset_angle(0)
-elbow_motor.stop(Stop.HOLD)
+elbow_motor.hold()
 
 # Initialize the base. First rotate it until the Touch Sensor
 # in the base is pressed. Reset the motor angle to make this
@@ -56,13 +56,13 @@ base_motor.run(-60)
 while not base_switch.pressed():
     wait(10)
 base_motor.reset_angle(0)
-base_motor.stop(Stop.HOLD)
+base_motor.hold()
 
 # Initialize the gripper. First rotate the motor until it stalls.
 # Stalling means that it cannot move any further. This position
 # corresponds to the closed position. Then rotate the motor
 # by 90 degrees such that the gripper is open.
-gripper_motor.run_until_stalled(200, Stop.COAST, 50)
+gripper_motor.run_until_stalled(200, then=Stop.COAST, duty_limit=50)
 gripper_motor.reset_angle(0)
 gripper_motor.run_target(200, -90)
 
@@ -73,13 +73,13 @@ def robot_pick(position):
     # raises the elbow to pick up the object.
 
     # Rotate to the pick-up position.
-    base_motor.run_target(60, position, Stop.HOLD)
+    base_motor.run_target(60, position)
     # Lower the arm.
     elbow_motor.run_target(60, -40)
     # Close the gripper to grab the wheel stack.
-    gripper_motor.run_until_stalled(200, Stop.HOLD, 50)
+    gripper_motor.run_until_stalled(200, then=Stop.HOLD, duty_limit=50)
     # Raise the arm to lift the wheel stack.
-    elbow_motor.run_target(60, 0, Stop.HOLD)
+    elbow_motor.run_target(60, 0)
 
 
 def robot_release(position):
@@ -88,13 +88,13 @@ def robot_release(position):
     # release the object. Then it raises its arm again.
 
     # Rotate to the drop-off position.
-    base_motor.run_target(60, position, Stop.HOLD)
+    base_motor.run_target(60, position)
     # Lower the arm to put the wheel stack on the ground.
     elbow_motor.run_target(60, -40)
     # Open the gripper to release the wheel stack.
     gripper_motor.run_target(200, -90)
     # Raise the arm.
-    elbow_motor.run_target(60, 0, Stop.HOLD)
+    elbow_motor.run_target(60, 0)
 
 
 # Play three beeps to indicate that the initialization is complete.

--- a/official_models/ev3/education_core/robot_arm/main.py
+++ b/official_models/ev3/education_core/robot_arm/main.py
@@ -25,8 +25,8 @@ base_motor = Motor(Port.C, Direction.COUNTERCLOCKWISE, [12, 36])
 
 # Limit the elbow and base accelerations. This results in
 # very smooth motion. Like an industrial robot.
-elbow_motor.set_run_settings(60, 120)
-base_motor.set_run_settings(60, 120)
+elbow_motor.control.limits(speed=60, acceleration=120)
+base_motor.control.limits(speed=60, acceleration=120)
 
 # Set up the Touch Sensor. It acts as an end-switch in the base
 # of the robot arm. It defines the starting point of the base.


### PR DESCRIPTION
Breaking changes were made in the motor API.

The `stop(Stop.*)` methods was split into explicit methods and the stop argument in `run_*` methods was renamed and the default value changed in some cases.