### PR TITLE
Fix gyro_bot failing to leave stand.

### DIFF
--- a/official_models/ev3/education_core/gyro_boy/main.py
+++ b/official_models/ev3/education_core/gyro_boy/main.py
@@ -249,7 +249,7 @@ while True:
 
         # calculate robot body angle and speed
         gyro_sensor_value = gyro_sensor.speed()
-        gyro_offset *= (1 - GYRO_OFFSET_FACTOR) * gyro_offset
+        gyro_offset *= (1 - GYRO_OFFSET_FACTOR)
         gyro_offset += GYRO_OFFSET_FACTOR * gyro_sensor_value
         robot_body_rate = gyro_sensor_value - gyro_offset
         robot_body_angle += robot_body_rate * average_control_loop_period


### PR DESCRIPTION
Remove extra gyro_offset factor that causes gyro_bot to not leave the stand.
My gyro sensor has an offset of -17 which causes gyro_offset to become very large with this calculation.
Since the code is using the `*=` operator, the current calculation is `(1 - GYRO_OFFSET_FACTOR) * gyro_offset * gyro_offset`, but I believe the desired calculation is `(1 - GYRO_OFFSET_FACTOR) * gyro_offset` to make this moving average correct.