### PR TITLE
sets/trains: fix link to tilt sensor

### DIFF
--- a/sets/trains/generic/slope_detection/README.md
+++ b/sets/trains/generic/slope_detection/README.md
@@ -5,7 +5,7 @@ Made by: The Pybricks Authors
 ## Introduction
 
 This project shows how you can integrate the
-[Tilt Sensor](https://docs.pybricks.com/en/latest/pupdevices.html#tilt-sensor)
+[Tilt Sensor][tiltsensor]
 in your LEGO trains. You can use this sensor to detect a slope in the rail
 track.
 
@@ -17,7 +17,7 @@ more. Then it drives back down. You can watch a video
 
 ## Requirements
 - Generic LEGO train, such as 60197 or 60198
-- Powered Up [Tilt Sensor](https://docs.pybricks.com/en/latest/pupdevices.html#tilt-sensor)
+- Powered Up [Tilt Sensor][tiltsensor]
 
 ## Building instructions
 Build the train using the standard instructions. Mount the Tilt Sensor anywhere
@@ -30,3 +30,5 @@ with the cable should face towards the front: in the direction of driving.
 
 ## Programming and running instructions
 The train must start on a horizontal track. Then run the program.
+
+[tiltsensor]: https://docs.pybricks.com/en/latest/pupdevices/tiltsensor.html


### PR DESCRIPTION
Fixes the dead link to the tilt sensor documentation.