### PR TITLE
sets/technic/*/remote: swap left/right controls

### DIFF
--- a/sets/technic/42099-off-roader/powered-up-remote/main.py
+++ b/sets/technic/42099-off-roader/powered-up-remote/main.py
@@ -32,21 +32,21 @@ while True:
     # Check which buttons are pressed.
     pressed = remote.buttons.pressed()
 
-    # Choose the steer angle based on the left controls.
+    # Choose the steer angle based on the right controls.
     steer_angle = 0
-    if Button.LEFT_PLUS in pressed:
+    if Button.RIGHT_MINUS in pressed:
         steer_angle -= 75
-    if Button.LEFT_MINUS in pressed:
+    if Button.RIGHT_PLUS in pressed:
         steer_angle += 75
 
     # Steer to the selected angle.
     steer.run_target(500, steer_angle, wait=False)
 
-    # Choose the drive speed based on the right controls.
+    # Choose the drive speed based on the left controls.
     drive_speed = 0
-    if Button.RIGHT_PLUS in pressed:
+    if Button.LEFT_PLUS in pressed:
         drive_speed += 1000
-    if Button.RIGHT_MINUS in pressed:
+    if Button.LEFT_MINUS in pressed:
         drive_speed -= 1000
 
     # Apply the selected speed.

--- a/sets/technic/42124-off-road-buggy/powered-up-remote/main.py
+++ b/sets/technic/42124-off-road-buggy/powered-up-remote/main.py
@@ -30,21 +30,21 @@ while True:
     # Check which buttons are pressed.
     pressed = remote.buttons.pressed()
 
-    # Choose the steer angle based on the left controls.
+    # Choose the steer angle based on the right controls.
     steer_angle = 0
-    if Button.LEFT_PLUS in pressed:
+    if Button.RIGHT_MINUS in pressed:
         steer_angle -= 75
-    if Button.LEFT_MINUS in pressed:
+    if Button.RIGHT_PLUS in pressed:
         steer_angle += 75
 
     # Steer to the selected angle.
     steer.run_target(500, steer_angle, wait=False)
 
-    # Choose the drive speed based on the right controls.
+    # Choose the drive speed based on the left controls.
     drive_speed = 0
-    if Button.RIGHT_PLUS in pressed:
+    if Button.LEFT_PLUS in pressed:
         drive_speed += 1000
-    if Button.RIGHT_MINUS in pressed:
+    if Button.LEFT_MINUS in pressed:
         drive_speed -= 1000
 
     # Apply the selected speed.


### PR DESCRIPTION
In RC toys, there is a defacto standard that throttle is on the left and steering is on the right, so this configuration should be more natural to anyone who has used other RC toys.

